### PR TITLE
Uses temp tables, patient_dimension, updated paths

### DIFF
--- a/CLICMetric-ACT-2019MSSql.sql
+++ b/CLICMetric-ACT-2019MSSql.sql
@@ -1,7 +1,7 @@
--- Replace @CRCSchema with the proper schema name
+-- Replace dbo with the proper schema name
 
-IF OBJECT_ID('@CRCSchema.CTSA_CLIC_METRIC', 'U') IS NOT NULL          -- Drop table if it exists
-  DROP TABLE @CRCSchema.CTSA_CLIC_METRIC;
+IF OBJECT_ID('CTSA_CLIC_METRIC', 'U') IS NOT NULL          -- Drop table if it exists
+  DROP TABLE CTSA_CLIC_METRIC;
 
 -- Create dest table
 CREATE TABLE CTSA_CLIC_METRIC (
@@ -11,38 +11,57 @@ CREATE TABLE CTSA_CLIC_METRIC (
 	Percent_Standards			float(53)   NULL,
 	Values_Present		VARCHAR(100)  NULL
 );
-  
-
-
-with  PTS_VISIT_2019 AS (SELECT DISTINCT patient_num  PATIENT_NUM 
-    FROM @CRCSchema.VISIT_DIMENSION WHERE 
+ 
+SELECT DISTINCT patient_num  PATIENT_NUM into #pts_visit_2019
+    FROM VISIT_DIMENSION WHERE 
         VISIT_DIMENSION.START_DATE >= DATEFROMPARTS(2019,01,01) AND VISIT_DIMENSION.START_DATE <= DATEFROMPARTS(2019,12,31)
-        --ORDER BY PATIENT_NUM
-  ),
-  DEN AS 
-  ( SELECT COUNT(DISTINCT patient_num)  cnt 
-    FROM PTS_VISIT_2019)
+
+create index ptsvisit2019 on #pts_visit_2019(patient_num)
+
+SELECT COUNT(DISTINCT patient_num) cnt into #cnt 
+    FROM #PTS_VISIT_2019
+    
+create index cnt2019 on #cnt(cnt)
     
   INSERT INTO CTSA_CLIC_METRIC 
   SELECT 'Patient Dimension Unique Patients' AS domain, null AS Patients_with_Standards,
  	cnt AS UNIQUE_TOTAL_PATIENTS,
  	null AS Percent_Standards,
  	'Not Applicable' AS Values_Present
- FROM den d
-UNION ALL
+ FROM #cnt
+ 
+  INSERT INTO CTSA_CLIC_METRIC 
  SELECT 'Unique Patient With Birth Date' AS domain,
  	num.cnt AS Patients_with_Standards,
-		den.cnt AS UNIQUE_TOTAL_PATIENTS,
-			ROUND(100.0 * num.cnt/den.cnt,1) AS Percent_Standards,
+		cnt.cnt AS UNIQUE_TOTAL_PATIENTS,
+			ROUND(100.0 * num.cnt/cnt.cnt,1) AS Percent_Standards,
 				    'Not Applicable' AS Values_Present
   FROM (SELECT COUNT(DISTINCT P.patient_num) cnt
-       	       FROM @CRCSchema.PATIENT_DIMENSION P
-                JOIN PTS_VISIT_2019 D ON D.PATIENT_NUM = P.PATIENT_NUM
+       	       FROM PATIENT_DIMENSION P
+                JOIN #PTS_VISIT_2019 D ON D.PATIENT_NUM = P.PATIENT_NUM
 	       WHERE birth_date IS NOT NULL 
                	     AND YEAR(BIRTH_DATE)>1900
-		     	 AND YEAR(BIRTH_DATE) < YEAR(GETDATE())) num,
-	den
-UNION ALL
+		     	 AND YEAR(BIRTH_DATE) < YEAR(GETDATE())) num
+		     	 full outer join #cnt cnt on 1=1
+
+// jgk I made a version that uses the patient dimenstion
+// I specify the std ACT code so would need customization
+  INSERT INTO CTSA_CLIC_METRIC 
+ SELECT 'Unique Patients With Gender' AS domain,
+ 	num.cnt AS Patients_with_Standards,
+		cnt.cnt AS UNIQUE_TOTAL_PATIENTS,
+			ROUND(100.0 * num.cnt/cnt.cnt,1) AS Percent_Standards,
+				    'Not Applicable' AS Values_Present
+  FROM (SELECT COUNT(DISTINCT P.patient_num) cnt
+       	       FROM PATIENT_DIMENSION P
+                JOIN #PTS_VISIT_2019 D ON D.PATIENT_NUM = P.PATIENT_NUM
+	       WHERE sex_cd IN ('M','F','A','NI','O') ) num
+		     	 full outer join #cnt cnt on 1=1
+		     	 
+
+
+/* This version relies on the fact table:
+  INSERT INTO CTSA_CLIC_METRIC 
  SELECT 'Unique Patients With Gender' AS domain,
  	num.cnt AS Patients_with_Standards,
 	den.cnt AS UNIQUE_TOTAL_PATIENTS,
@@ -50,13 +69,15 @@ UNION ALL
 	'Not Applicable' AS Values_Present
     FROM
 	(SELECT COUNT(DISTINCT OBS.patient_num) cnt 
-        FROM @CRCSchema.OBSERVATION_FACT obs
-             JOIN PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
-        WHERE EXISTS (SELECT * FROM @CRCSchema.CONCEPT_DIMENSION c 
-                        WHERE c.concept_path LIKE  '\ACT\Demographics\Sex\%' AND obs.concept_cd = c.concept_cd)) num,
-	den
+        FROM OBSERVATION_FACT obs
+             JOIN #PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
+        WHERE EXISTS (SELECT * FROM CONCEPT_DIMENSION c 
+                        WHERE c.concept_path LIKE  '\ACT\Demographics\Sex\%' AND obs.concept_cd = c.concept_cd)) num
+        		     	 full outer join #cnt den on 1=1
+*/
 
-UNION ALL
+/* jgk had to change to \ACT\PROCEDURES\% */
+  INSERT INTO CTSA_CLIC_METRIC 
  SELECT 'Unique Patients With Procedure (ICD9/ICD10/CPT/HCPCS)' AS domain,
  	num.cnt AS Patients_with_Standards,
 	den.cnt AS UNIQUE_TOTAL_PATIENTS,
@@ -64,14 +85,16 @@ UNION ALL
 	'Not Applicable' AS Values_Present
     FROM
 	(SELECT COUNT(DISTINCT OBS.patient_num) cnt 
-    FROM @CRCSchema.OBSERVATION_FACT obs
-        JOIN PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
+    FROM OBSERVATION_FACT obs
+        JOIN #PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
    	WHERE OBS.START_DATE >= DATEFROMPARTS(2019,01,01) AND OBS.START_DATE <= DATEFROMPARTS(2019,12,31)
-            AND EXISTS (SELECT * FROM @CRCSchema.CONCEPT_DIMENSION c 
-                        WHERE c.concept_path LIKE  '\ACT\PROCEDURE\%' AND obs.concept_cd = c.concept_cd))num,
-	den
+            AND obs.concept_cd in (SELECT concept_cd FROM CONCEPT_DIMENSION c 
+                        WHERE c.concept_path LIKE  '\ACT\PROCEDURES\%' )) num
+            		     	 full outer join #cnt den on 1=1
 	
-UNION ALL
+	select * from ctsa_clic_metric
+
+  INSERT INTO CTSA_CLIC_METRIC 
  SELECT 'Unique Patients With Meds (RxNorm/NDC)' AS domain,
  	num.cnt AS Patients_with_Standards,
 	den.cnt AS UNIQUE_TOTAL_PATIENTS,
@@ -79,28 +102,31 @@ UNION ALL
 	'Not Applicable' AS Values_Present
     FROM
 	(SELECT COUNT(DISTINCT OBS.patient_num) cnt 
-        FROM @CRCSchema.OBSERVATION_FACT obs
-        JOIN PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
+        FROM OBSERVATION_FACT obs
+        JOIN #PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
         	WHERE OBS.START_DATE >= DATEFROMPARTS(2019,01,01) AND OBS.START_DATE <= DATEFROMPARTS(2019,12,31)
-            AND EXISTS (SELECT * FROM @CRCSchema.CONCEPT_DIMENSION c 
-                        WHERE c.concept_path LIKE  '\ACT\Medications\%' AND obs.concept_cd = c.concept_cd))num,
-	den
+            AND EXISTS (SELECT * FROM CONCEPT_DIMENSION c 
+                        WHERE c.concept_path LIKE  '\ACT\Medications\%' AND obs.concept_cd = c.concept_cd))num
+                                		     	 full outer join #cnt den on 1=1
 	
-UNION ALL
+
+/* Had to change to \ACT\Lab\ from plural - jgk */
+  INSERT INTO CTSA_CLIC_METRIC 
  SELECT 'Unique Patients With Labs (LOINC)' AS domain,
  	num.cnt AS Patients_with_Standards,
 	den.cnt AS UNIQUE_TOTAL_PATIENTS,
 	ROUND(100.0 * num.cnt/den.cnt,1) AS Percent_Standards,
 	'Not Applicable' AS Values_Present
     FROM
-	(SELECT COUNT(DISTINCT OBS.patient_num) cnt FROM @CRCSchema.OBSERVATION_FACT obs
-            JOIN PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
+	(SELECT COUNT(DISTINCT OBS.patient_num) cnt FROM OBSERVATION_FACT obs
+            JOIN #PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
         	WHERE OBS.START_DATE >= DATEFROMPARTS(2019,01,01) AND OBS.START_DATE <= DATEFROMPARTS(2019,12,31)
-                AND EXISTS (SELECT * FROM @CRCSchema.CONCEPT_DIMENSION c 
-                        WHERE  concept_path like '\ACT\Labs\%' AND obs.concept_cd = c.concept_cd))num,
-	den
+                AND EXISTS (SELECT * FROM CONCEPT_DIMENSION c 
+                        WHERE  concept_path like '\ACT\Lab\%' AND obs.concept_cd = c.concept_cd))num
+                                		     	 full outer join #cnt den on 1=1
 	
-UNION ALL
+
+  INSERT INTO CTSA_CLIC_METRIC 
  SELECT 'Unique Patients With Diagnosis (ICD9 AND ICD10)' AS domain,
  	num.cnt AS Patients_with_Standards,
 	den.cnt AS UNIQUE_TOTAL_PATIENTS,
@@ -108,13 +134,13 @@ UNION ALL
 	'Not Applicable' AS Values_Present
     FROM
 	(SELECT COUNT(DISTINCT OBS.patient_num) cnt 
-        FROM @CRCSchema.OBSERVATION_FACT obs
-        JOIN PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
+        FROM OBSERVATION_FACT obs
+        JOIN #PTS_VISIT_2019 D ON D.PATIENT_NUM = OBS.PATIENT_NUM
         WHERE OBS.START_DATE >= DATEFROMPARTS(2019,01,01) AND OBS.START_DATE <= DATEFROMPARTS(2019,12,31)
-            AND EXISTS (SELECT * FROM @CRCSchema.CONCEPT_DIMENSION c 
+            AND EXISTS (SELECT * FROM CONCEPT_DIMENSION c 
                         WHERE ( c.concept_path LIKE  '\ACT\DIAGNOSIS\%' OR c.concept_path LIKE  '\Diagnoses\%')
-			      AND obs.concept_cd = c.concept_cd))num,
-			      den
-;
+			      AND obs.concept_cd = c.concept_cd))num
+			              		     	 full outer join #cnt den on 1=1
 
---select * from CTSA_CLIC_METRIC;
+
+select * from CTSA_CLIC_METRIC;


### PR DESCRIPTION
Hello, I made some optimizations to the MSSQL CLICMetric. It is much faster at our site (Mass General Brigham), though my code modifications could also use a little cleanup. Feel free to use any of this code!

Mainly I changed it to use temp tables instead of CTEs, because this is much faster in MSSQL. I also created a version of the code that pulls demographics from patient_dimension instead of the fact table, which is needed in our configuration. Finally, I modified a couple of the high-level paths to match what we have in our installation. I think my changes match the latest ontology, but it also could be an anomaly, so you'd definitely want to check that before you accept the pull request.